### PR TITLE
Experiment with C# 11 preview of abstract static interface methods and CallerArgumentExpression as cache key

### DIFF
--- a/src/Isle/Isle.Serilog.Benchmarks/Isle.Serilog.Benchmarks.csproj
+++ b/src/Isle/Isle.Serilog.Benchmarks/Isle.Serilog.Benchmarks.csproj
@@ -5,10 +5,12 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<LangVersion>preview</LangVersion>
+	<EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Isle/Isle.Serilog.Benchmarks/SerilogBenchmark.cs
+++ b/src/Isle/Isle.Serilog.Benchmarks/SerilogBenchmark.cs
@@ -27,7 +27,7 @@ public class SerilogBenchmark
         GlobalSetup();
     }
 
-    [GlobalSetup(Targets = new[] { nameof(InterpolatedWithManualDestructuring), nameof(InterpolatedWithLiteralValue) })]
+    [GlobalSetup(Targets = new[] { nameof(InterpolatedWithManualDestructuring), nameof(Interpolated2WithManualDestructuring) /*, nameof(InterpolatedWithLiteralValue) */})]
     public void GlobalSetupWithManualDestructuring()
     {
         GlobalSetup();
@@ -35,7 +35,7 @@ public class SerilogBenchmark
             .ConfigureSerilog(cfg => cfg.EnableMessageTemplateCaching = EnableCaching));
     }
 
-    [GlobalSetup(Targets = new[] { nameof(InterpolatedWithExplicitAutomaticDestructuring), nameof(InterpolatedWithImplicitAutomaticDestructuring) })]
+    [GlobalSetup(Targets = new[] { nameof(InterpolatedWithExplicitAutomaticDestructuring), nameof(Interpolated2WithExplicitAutomaticDestructuring), nameof(InterpolatedWithImplicitAutomaticDestructuring), nameof(Interpolated2WithImplicitAutomaticDestructuring) })]
     public void GlobalSetupWithAutoDestructuring()
     {
         GlobalSetup();
@@ -83,9 +83,30 @@ public class SerilogBenchmark
         _logger.InformationInterpolated($"The area of rectangle {Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {Perimeter}.");
     }
 
+    //[Benchmark]
+    //public void InterpolatedWithLiteralValue()
+    //{
+    //    _logger.InformationInterpolated2($"The area of rectangle {@Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {(LiteralValue) Perimeter.ToString()}.");
+    //}
+
     [Benchmark]
-    public void InterpolatedWithLiteralValue()
-    {
-        _logger.InformationInterpolated($"The area of rectangle {@Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {(LiteralValue) Perimeter.ToString()}.");
+    public void Interpolated2WithManualDestructuring() {
+        _logger.InformationInterpolated2($"The area of rectangle {@Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {Perimeter}.");
     }
+
+    [Benchmark]
+    public void Interpolated2WithExplicitAutomaticDestructuring() {
+        _logger.InformationInterpolated2($"The area of rectangle {@Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {Perimeter}.");
+    }
+
+    [Benchmark]
+    public void Interpolated2WithImplicitAutomaticDestructuring() {
+        _logger.InformationInterpolated2($"The area of rectangle {Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {Perimeter}.");
+    }
+
+    //[Benchmark]
+    //public void Interpolate2dWithLiteralValue() {
+    //    _logger.InformationInterpolated2($"The area of rectangle {@Rect} is Width * Height = {Area} and its perimeter is 2 * (Width + Height) = {(LiteralValue)Perimeter.ToString()}.");
+    //}
+
 }

--- a/src/Isle/Isle.Serilog.Tests/Isle.Serilog.Tests.csproj
+++ b/src/Isle/Isle.Serilog.Tests/Isle.Serilog.Tests.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+	<LangVersion>preview</LangVersion>
+	<EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Isle/Isle.Serilog.Tests/LoggerExtensions2Tests.cs
+++ b/src/Isle/Isle.Serilog.Tests/LoggerExtensions2Tests.cs
@@ -1,0 +1,34 @@
+﻿#nullable enable
+using System;
+using System.Globalization;
+using System.Linq;
+using NUnit.Framework;
+using FluentAssertions;
+using Serilog.Events;
+using Serilog.Parsing;
+using Isle.Extensions;
+
+
+namespace Isle.Serilog.Tests;
+
+[TestFixtureSource(nameof(FixtureArgs))]
+public class LoggerExtensions2Tests: BaseFixture {
+    public LoggerExtensions2Tests(LogEventLevel minLogEventLevel, bool enableCaching) : base(minLogEventLevel, enableCaching) {
+    }
+
+    [Test]
+    public void VerboseInterpolated2_Mixed() {
+
+        var arg1 = "Test";
+        var arg2 = 5000;
+        var arg3 = 4.5;
+        var arg4 = new TestObject(7, 11);
+        var arg5 = new int[] { 5, 4, 3 };
+
+        for(int i = 0; i < 2; ++i) {
+            Logger.VerboseInterpolated2($"ABCD{arg1}EFGH{arg2}IJKL{arg3}MNOP{arg4}QRST{arg5}UVWX");
+        }
+
+        LogEvents.Should().HaveCount(2);
+    }
+}

--- a/src/Isle/Isle.Serilog/Isle.Serilog.csproj
+++ b/src/Isle/Isle.Serilog/Isle.Serilog.csproj
@@ -13,6 +13,8 @@
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<Description>Adds support of structured logging using interpolated strings in C# 10 to Serilog.</Description>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	<LangVersion>preview</LangVersion>
+	<EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +24,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="TLogLevel.g.cs">
+      <DependentUpon>TLogLevel.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </None>
     <None Include="LoggerExtensions.g.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -47,6 +54,10 @@
       <PackagePath>/</PackagePath>
       <Pack>True</Pack>
     </None>
+    <None Update="TLogLevel.tt">
+      <LastGenOutput>TLogLevel.g.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
     <None Update="LoggerExtensions.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>LoggerExtensions.g.cs</LastGenOutput>
@@ -71,6 +82,11 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>LogHandlers.tt</DependentUpon>
+    </Compile>
+    <Compile Update="TLogLevel.g.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TLogLevel.tt</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/src/Isle/Isle.Serilog/TLogLevel.cs
+++ b/src/Isle/Isle.Serilog/TLogLevel.cs
@@ -1,0 +1,113 @@
+﻿using System.Buffers;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Serilog;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Isle.Serilog {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+    /// <summary>
+    /// Implemented in TLogLevel.g.cs
+    /// </summary>
+    /// <typeparam name="TSelf"></typeparam>
+    public interface IHasLogLevel<TSelf> where TSelf : IHasLogLevel<TSelf> {
+        static abstract LogEventLevel GetLevel();
+    }
+
+    enum StringPart {Literal, Formatted }
+
+    [InterpolatedStringHandler]
+    public ref struct LogISH<TLogLevel> where TLogLevel : IHasLogLevel<TLogLevel> {
+        //private readonly List<(StringPart StringPart,string Value)>? StringParts = default;
+
+        private readonly (StringPart Type, string LiteralOrName, object? V)[]? StringParts = default;
+
+        private readonly int LiteralLength;
+        private readonly int FormattedCount;
+
+        public bool IsEnabled => StringParts != null;
+
+        int stringPartCount = 0;
+
+        static ArrayPool<(StringPart Type, string LiteralOrName, object? V)> StringPartsArrayPool => ArrayPool<(StringPart Type, string LiteralOrName, object? V)>.Shared;
+
+        public LogISH(
+            int literalLength,
+            int formattedCount,
+            ILogger logger,
+            out bool isEnabled
+        ) {
+            isEnabled = logger.IsEnabled(TLogLevel.GetLevel());
+            LiteralLength = literalLength;
+            FormattedCount = formattedCount;
+            if (!isEnabled) return;
+
+            // formattedCount*2 + 1 is a reasonable assumption of the max number of string parts, but the spec
+            // offers no insights into whether AppendLiteral might be called multiple times consecutively, for
+            // instance in the case of added interpolated string $"aa{1}bb" + $"cc{2}" we might see "bb" and "cc"
+            // in seperate calls to AppendLiteral.
+            // So it might be a good idea to a an overflow check to the Append* methods and possibly Rent a larger
+            // array
+            StringParts = StringPartsArrayPool.Rent(formattedCount*2 + 1);
+        }
+
+        void Reset() {
+            StringPartsArrayPool.Return(StringParts!);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLiteral(string literal) =>
+            StringParts![stringPartCount++] = (StringPart.Literal, literal, null);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendFormatted<T>(T value, [CallerArgumentExpression("value")] string name = "") {
+            StringParts![stringPartCount++] = (StringPart.Formatted, name, value);
+        }
+
+
+        static readonly ConcurrentDictionary<string, MessageTemplate> CachedTemplates = new();
+        internal LogEvent GetLogEvent(ILogger logger, string handlerExpr, Exception? exception = null) {
+            if (CachedTemplates.TryGetValue(handlerExpr, out var template)) {
+                var logEvent = new LogEvent(
+                    DateTimeOffset.Now,
+                    TLogLevel.GetLevel(),
+                    exception,
+                    template,
+                    Array.Empty<LogEventProperty>());
+
+                foreach (var sp in StringParts.AsSpan(0, stringPartCount)) {
+                    if(sp.Type == StringPart.Formatted
+                        &&logger.BindProperty(sp.LiteralOrName, sp.V, true, out var property)) 
+                    {
+                        logEvent.AddOrUpdateProperty(property);
+                    }
+                }
+                Reset();
+                return logEvent;
+            }
+
+            SimpleLogEventBuilder builder = new();
+            builder.PublicInitialize(LiteralLength, FormattedCount, logger);
+            foreach(var sp in StringParts.AsSpan(0, stringPartCount)) {
+                switch (sp.Type) {
+                    case StringPart.Literal:
+                        builder.AppendLiteral(sp.LiteralOrName);
+                        break;
+                    case StringPart.Formatted:
+                        builder.AppendFormatted(sp.LiteralOrName, sp.V, 0, null);
+                        break;
+                }
+            }
+            Reset();
+            template = builder.GetMessageTemplate();
+            CachedTemplates.TryAdd(handlerExpr, template);
+            return builder.BuildAndReset(template, TLogLevel.GetLevel(), exception);
+        }
+    }
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+}

--- a/src/Isle/Isle.Serilog/TLogLevel.g.cs
+++ b/src/Isle/Isle.Serilog/TLogLevel.g.cs
@@ -1,0 +1,148 @@
+﻿#nullable enable
+using System.Runtime.CompilerServices;
+using System.Text;
+using Serilog;
+using Serilog.Events;
+
+namespace Isle.Serilog;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+
+public readonly struct LogLevelVerbose: IHasLogLevel<LogLevelVerbose> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Verbose;
+}
+
+
+public readonly struct LogLevelDebug: IHasLogLevel<LogLevelDebug> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Debug;
+}
+
+
+public readonly struct LogLevelInformation: IHasLogLevel<LogLevelInformation> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Information;
+}
+
+
+public readonly struct LogLevelWarning: IHasLogLevel<LogLevelWarning> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Warning;
+}
+
+
+public readonly struct LogLevelError: IHasLogLevel<LogLevelError> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Error;
+}
+
+
+public readonly struct LogLevelFatal: IHasLogLevel<LogLevelFatal> {
+    public static LogEventLevel GetLevel() => LogEventLevel.Fatal;
+}
+
+
+
+/// <summary>
+/// Provides extensions methods for <see cref="ILogger" /> to enable structured logging using interpolated strings.
+/// But now taking advantage of the abstract static GetLevel method on IHasLogLevel to avoid duplicate InterpolatedStringHandlers
+/// </summary>
+public static class TLoggerExtensions
+{
+    public static void Log<TLogLevel>(
+		this ILogger logger,
+		Exception? exception,
+		ref LogISH<TLogLevel> handler, 
+		[CallerArgumentExpression("handler")] string handlerExpr = "") 
+		where TLogLevel : IHasLogLevel<TLogLevel> 
+	{
+		if (handler.IsEnabled)
+		{
+			var logEvent = handler.GetLogEvent(logger, handlerExpr, exception);
+			logger.Write(logEvent);
+		}
+	}
+
+    public static void Log<TLogLevel>(this ILogger logger, ref LogISH<TLogLevel> handler, [CallerArgumentExpression("handler")] string handlerExpr = "") where TLogLevel : IHasLogLevel<TLogLevel>
+		=> Log(logger, null, ref handler, handlerExpr);
+
+	public static void VerboseInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelVerbose> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void VerboseInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelVerbose> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+	public static void DebugInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelDebug> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void DebugInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelDebug> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+	public static void InformationInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelInformation> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void InformationInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelInformation> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+	public static void WarningInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelWarning> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void WarningInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelWarning> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+	public static void ErrorInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelError> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void ErrorInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelError> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+	public static void FatalInterpolated2(
+		this ILogger logger,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelFatal> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, ref handler, handlerExpr);
+
+	public static void FatalInterpolated2(
+		this ILogger logger,
+		Exception? exception,
+		[InterpolatedStringHandlerArgument("logger")] ref LogISH<LogLevelFatal> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger, exception, ref handler, handlerExpr);
+
+
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+}

--- a/src/Isle/Isle.Serilog/TLogLevel.tt
+++ b/src/Isle/Isle.Serilog/TLogLevel.tt
@@ -1,0 +1,74 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".g.cs" #>
+<#
+	string[] logEventLevels = { "Verbose", "Debug", "Information", "Warning", "Error", "Fatal" }; 
+	
+	string GetTypeName(string logEventLevel) => $"LogISH<LogLevel{logEventLevel}>";
+	
+	string GetMethodName(string logEventLevel) => $"{logEventLevel}Interpolated2";
+
+#>
+#nullable enable
+using System.Runtime.CompilerServices;
+using System.Text;
+using Serilog;
+using Serilog.Events;
+
+namespace Isle.Serilog;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+<# foreach (var logEventLevel in logEventLevels) { #>
+
+public readonly struct LogLevel<#=logEventLevel#>: IHasLogLevel<LogLevel<#=logEventLevel#>> {
+    public static LogEventLevel GetLevel() => LogEventLevel.<#=logEventLevel#>;
+}
+
+<# } #>
+
+
+/// <summary>
+/// Provides extensions methods for <see cref="ILogger" /> to enable structured logging using interpolated strings.
+/// But now taking advantage of the abstract static GetLevel method on IHasLogLevel to avoid duplicate InterpolatedStringHandlers
+/// </summary>
+public static class TLoggerExtensions
+{
+    public static void Log<TLogLevel>(
+		this ILogger logger,
+		Exception? exception,
+		ref LogISH<TLogLevel> handler, 
+		[CallerArgumentExpression("handler")] string handlerExpr = "") 
+		where TLogLevel : IHasLogLevel<TLogLevel> 
+	{
+		if (handler.IsEnabled)
+		{
+			var logEvent = handler.GetLogEvent(logger, handlerExpr, exception);
+			logger.Write(logEvent);
+		}
+	}
+
+    public static void Log<TLogLevel>(this ILogger logger, ref LogISH<TLogLevel> handler, [CallerArgumentExpression("handler")] string handlerExpr = "") where TLogLevel : IHasLogLevel<TLogLevel>
+		=> Log(logger, null, ref handler, handlerExpr);
+
+<# foreach (var logEventLevel in logEventLevels) { #>
+<# foreach (var withException in new[] { false, true }) { #>
+	public static void <#= GetMethodName(logEventLevel) #>(
+		this ILogger logger,
+<# if (withException) { #>
+		Exception? exception,
+<# } #>
+		[InterpolatedStringHandlerArgument("logger"<#= logEventLevel == null ? ", \"logEventLevel\"" : "" #>)] ref <#= GetTypeName(logEventLevel) #> handler,
+		[CallerArgumentExpression("handler")] string handlerExpr = ""
+	) => Log( logger,<# if (withException) { #> exception,<# } #> ref handler, handlerExpr);
+
+<# } #>
+<# } #>
+
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+}


### PR DESCRIPTION
Hey.

I've implemented something very similar at work and had a few ideas I wanted to try out. Since our solutions are so similar but you have a nice benchmark setup it seemed sensible to try my ideas here and share the results.

The experiments are:

- Using C# 11 preview of abstract static interface methods to eliminate the need for multiple InterpolatedStringHandlers.

- Using CallerArgumentExpression in extensions methods (handlerExpr) to get the original interpolated string expression and using it as cache key. The value of handlerExpr takes the form: $"ABCD{arg1}EFGH{arg2}IJKL{arg3}MNOP{arg4}QRST{arg5}UVWX"
It doesn't seem possible to pass handlerExpr as an argument to the interpolation handler, which is a shame, since it would have allowed skipping recording anything other than the arguments.

I don't use ArrayPool in my own implementation since I'm a little scared of leaks. I only added it here for fun to get better results in the benchmark.
The experiment is a little rough and I'm not sure it's and apples to apples comparison but the results are good:

```
|                                          Method | IsEnabled | EnableCaching |         Mean | Ratio |   Gen0 | Allocated | Alloc Ratio |
|------------------------------------------------ |---------- |-------------- |-------------:|------:|-------:|----------:|------------:|
|                                        Standard |     False |         False |    14.748 ns |  1.00 |      - |         - |          NA |
|             InterpolatedWithManualDestructuring |     False |         False |     4.267 ns |  0.30 |      - |         - |          NA |
|  InterpolatedWithExplicitAutomaticDestructuring |     False |         False |     4.035 ns |  0.28 |      - |         - |          NA |
|  InterpolatedWithImplicitAutomaticDestructuring |     False |         False |     4.410 ns |  0.31 |      - |         - |          NA |
|            Interpolated2WithManualDestructuring |     False |         False |     4.811 ns |  0.33 |      - |         - |          NA |
| Interpolated2WithExplicitAutomaticDestructuring |     False |         False |     4.226 ns |  0.29 |      - |         - |          NA |
| Interpolated2WithImplicitAutomaticDestructuring |     False |         False |     4.594 ns |  0.32 |      - |         - |          NA |
|                                                 |           |               |              |       |        |           |             |
|                                        Standard |     False |          True |    14.830 ns |  1.00 |      - |         - |          NA |
|             InterpolatedWithManualDestructuring |     False |          True |     4.361 ns |  0.30 |      - |         - |          NA |
|  InterpolatedWithExplicitAutomaticDestructuring |     False |          True |     6.292 ns |  0.43 |      - |         - |          NA |
|  InterpolatedWithImplicitAutomaticDestructuring |     False |          True |     5.452 ns |  0.37 |      - |         - |          NA |
|            Interpolated2WithManualDestructuring |     False |          True |     5.251 ns |  0.35 |      - |         - |          NA |
| Interpolated2WithExplicitAutomaticDestructuring |     False |          True |     4.116 ns |  0.28 |      - |         - |          NA |
| Interpolated2WithImplicitAutomaticDestructuring |     False |          True |     4.173 ns |  0.27 |      - |         - |          NA |
|                                                 |           |               |              |       |        |           |             |
|                                        Standard |      True |         False | 2,889.727 ns |  1.00 | 0.7706 |    1616 B |        1.00 |
|             InterpolatedWithManualDestructuring |      True |         False | 3,973.308 ns |  1.37 | 1.3351 |    2792 B |        1.73 |
|  InterpolatedWithExplicitAutomaticDestructuring |      True |         False | 4,064.250 ns |  1.40 | 1.3351 |    2792 B |        1.73 |
|  InterpolatedWithImplicitAutomaticDestructuring |      True |         False | 4,104.125 ns |  1.43 | 1.3199 |    2760 B |        1.71 |
|            Interpolated2WithManualDestructuring |      True |         False | 2,996.425 ns |  1.04 | 0.7591 |    1592 B |        0.99 |
| Interpolated2WithExplicitAutomaticDestructuring |      True |         False | 3,039.021 ns |  1.05 | 0.7591 |    1592 B |        0.99 |
| Interpolated2WithImplicitAutomaticDestructuring |      True |         False | 2,979.040 ns |  1.03 | 0.7591 |    1592 B |        0.99 |
|                                                 |           |               |              |       |        |           |             |
|                                        Standard |      True |          True | 2,862.356 ns |  1.00 | 0.7706 |    1616 B |        1.00 |
|             InterpolatedWithManualDestructuring |      True |          True | 3,438.223 ns |  1.20 | 0.8698 |    1824 B |        1.13 |
|  InterpolatedWithExplicitAutomaticDestructuring |      True |          True | 3,287.397 ns |  1.15 | 0.8698 |    1824 B |        1.13 |
|  InterpolatedWithImplicitAutomaticDestructuring |      True |          True | 3,350.591 ns |  1.19 | 0.8850 |    1856 B |        1.15 |
|            Interpolated2WithManualDestructuring |      True |          True | 3,013.102 ns |  1.06 | 0.7591 |    1592 B |        0.99 |
| Interpolated2WithExplicitAutomaticDestructuring |      True |          True | 3,006.917 ns |  1.06 | 0.7591 |    1592 B |        0.99 |
| Interpolated2WithImplicitAutomaticDestructuring |      True |          True | 3,022.641 ns |  1.06 | 0.7591 |    1592 B |        0.99 |
```

Hopefully they'll expand the capabilities of interpolated string handlers in C#11. My personal wishlist includes:
- Being able to pass constants to the constructor
- Getting the original string expression
- Guarantees on how many calls to AppendLiteral you can expect
- Maybe an AppendDone method
- The ability to somehow get a stack allocated Span<Char> for alloc free string composistion. There are probably more complications to this than I've thought of though.

Anyways that's it. Thanks for building this project :)